### PR TITLE
Update composer install command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,18 +39,26 @@
     },
     "scripts": {
         "post-root-package-install": [
-            "php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+            "@copy-env-file"
         ],
         "post-create-project-cmd": [
-            "php artisan key:generate"
+            "@generate-security-key"
         ],
         "post-install-cmd": [
             "Illuminate\\Foundation\\ComposerScripts::postInstall",
+            "@copy-env-file"
+            "@generate-security-key"
             "php artisan optimize"
         ],
         "post-update-cmd": [
             "Illuminate\\Foundation\\ComposerScripts::postUpdate",
             "php artisan optimize"
+        ],
+        "copy-env-file": [
+            "php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+        ],
+        "generate-security-key": [
+            "php artisan key:generate"
         ]
     },
     "config": {


### PR DESCRIPTION
### What's this PR do?
Modify the behavior when `composer install` command is executed.
This creates a copy from `.env.example` to `.env` and generates the security key Laravel utilizes.

### Steps to Test or Reproduce
Delete the `vendor` folder and trigger a `composer install` by either spinning up the containers with `docker-compose up -d` or `docker-compose run composer`